### PR TITLE
Fixed Missing Technical Layers, Through Hole Parts

### DIFF
--- a/Resistor_Horizontal_RM10mm.kicad_mod
+++ b/Resistor_Horizontal_RM10mm.kicad_mod
@@ -14,6 +14,6 @@
   (fp_line (start 2.61874 -1.27) (end 2.61874 1.27) (layer F.SilkS) (width 0.381))
   (fp_line (start 2.61874 1.27) (end -2.46126 1.27) (layer F.SilkS) (width 0.381))
   (fp_line (start -2.46126 1.27) (end -2.46126 -1.27) (layer F.SilkS) (width 0.381))
-  (pad 1 thru_hole circle (at -5.00126 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
-  (pad 2 thru_hole circle (at 5.15874 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
+  (pad 1 thru_hole circle (at -5.00126 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
+  (pad 2 thru_hole circle (at 5.15874 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
 )

--- a/Resistor_Horizontal_RM15mm.kicad_mod
+++ b/Resistor_Horizontal_RM15mm.kicad_mod
@@ -14,6 +14,6 @@
   (fp_line (start 5.19938 -1.27) (end 5.19938 1.27) (layer F.SilkS) (width 0.381))
   (fp_line (start 5.19938 1.27) (end -4.96062 1.27) (layer F.SilkS) (width 0.381))
   (fp_line (start -4.96062 1.27) (end -4.96062 -1.27) (layer F.SilkS) (width 0.381))
-  (pad 1 thru_hole circle (at -7.50062 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
-  (pad 2 thru_hole circle (at 7.73938 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
+  (pad 1 thru_hole circle (at -7.50062 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
+  (pad 2 thru_hole circle (at 7.73938 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
 )

--- a/Resistor_Horizontal_RM20mm.kicad_mod
+++ b/Resistor_Horizontal_RM20mm.kicad_mod
@@ -15,6 +15,6 @@
   (fp_line (start 7.78002 -2.54) (end 7.78002 2.54) (layer F.SilkS) (width 0.381))
   (fp_line (start 7.78002 2.54) (end -7.45998 2.54) (layer F.SilkS) (width 0.381))
   (fp_line (start -7.45998 2.54) (end -7.45998 -1.27) (layer F.SilkS) (width 0.381))
-  (pad 1 thru_hole circle (at -9.99998 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
-  (pad 2 thru_hole circle (at 10.32002 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
+  (pad 1 thru_hole circle (at -9.99998 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
+  (pad 2 thru_hole circle (at 10.32002 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
 )

--- a/Resistor_Horizontal_RM25mm.kicad_mod
+++ b/Resistor_Horizontal_RM25mm.kicad_mod
@@ -14,6 +14,6 @@
   (fp_line (start -8.68934 3.81) (end 9.09066 3.81) (layer F.SilkS) (width 0.381))
   (fp_line (start 9.09066 3.81) (end 9.09066 -3.81) (layer F.SilkS) (width 0.381))
   (fp_line (start 9.09066 -3.81) (end -8.68934 -3.81) (layer F.SilkS) (width 0.381))
-  (pad 1 thru_hole circle (at -12.49934 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
-  (pad 2 thru_hole circle (at 12.49934 0) (size 2.30124 2.30124) (drill 1.19888) (layers *.Cu))
+  (pad 1 thru_hole circle (at -12.49934 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
+  (pad 2 thru_hole circle (at 12.49934 0) (size 2.30124 2.30124) (drill 1.19888) (layers *.Cu *.Mask *.SilkS))
 )

--- a/Resistor_Horizontal_RM30mm.kicad_mod
+++ b/Resistor_Horizontal_RM30mm.kicad_mod
@@ -14,6 +14,6 @@
   (fp_line (start 11.66876 -5.08) (end 11.66876 5.08) (layer F.SilkS) (width 0.381))
   (fp_line (start 11.66876 5.08) (end -11.19124 5.08) (layer F.SilkS) (width 0.381))
   (fp_line (start -11.19124 5.08) (end -11.19124 -5.08) (layer F.SilkS) (width 0.381))
-  (pad 1 thru_hole circle (at -15.00124 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
-  (pad 2 thru_hole circle (at 15.47876 0) (size 2.30124 2.30124) (drill 1.19888) (layers *.Cu))
+  (pad 1 thru_hole circle (at -15.00124 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
+  (pad 2 thru_hole circle (at 15.47876 0) (size 2.30124 2.30124) (drill 1.19888) (layers *.Cu *.Mask *.SilkS))
 )

--- a/Resistor_Vertical_RM5mm.kicad_mod
+++ b/Resistor_Vertical_RM5mm.kicad_mod
@@ -10,6 +10,6 @@
   )
   (fp_line (start -0.09906 0) (end 0.9017 0) (layer F.SilkS) (width 0.381))
   (fp_circle (center -2.49936 0) (end 0 0) (layer F.SilkS) (width 0.381))
-  (pad 1 thru_hole circle (at -2.49936 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
-  (pad 2 thru_hole circle (at 2.5019 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
+  (pad 1 thru_hole circle (at -2.49936 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
+  (pad 2 thru_hole circle (at 2.5019 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
 )

--- a/Resistor_Vertical_RM7.5mm.kicad_mod
+++ b/Resistor_Vertical_RM7.5mm.kicad_mod
@@ -10,6 +10,6 @@
   )
   (fp_line (start 1.25222 0) (end 2.15138 0) (layer F.SilkS) (width 0.381))
   (fp_circle (center -3.74904 0) (end 1.25222 0) (layer F.SilkS) (width 0.381))
-  (pad 1 thru_hole circle (at -3.74904 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
-  (pad 2 thru_hole circle (at 3.75158 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu))
+  (pad 1 thru_hole circle (at -3.74904 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
+  (pad 2 thru_hole circle (at 3.75158 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.Mask *.SilkS))
 )


### PR DESCRIPTION
Through hole parts missing technical layers for silkscreen and solder mask.
Using existing parts without editing pads would result in an unusable board.
