### PR TITLE
Align 10mm horizontal resister 3d model to pads

### DIFF
--- a/Resistor_Horizontal_RM10mm.kicad_mod
+++ b/Resistor_Horizontal_RM10mm.kicad_mod
@@ -20,7 +20,7 @@
   (pad 1 thru_hole circle (at 0 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.SilkS *.Mask))
   (pad 2 thru_hole circle (at 10.16 0) (size 1.99898 1.99898) (drill 1.00076) (layers *.Cu *.SilkS *.Mask))
   (model Resistors_ThroughHole.3dshapes/Resistor_Horizontal_RM10mm.wrl
-    (at (xyz 0 0 0))
+    (at (xyz 0.2 0 0))
     (scale (xyz 0.4 0.4 0.4))
     (rotate (xyz 0 0 0))
   )


### PR DESCRIPTION
The 10mm horizontal resistor 3d model is not aligned with the pads. Move the model to align with the pads.